### PR TITLE
Fix iterator/operator->, back wraparound, non-trivial copy indexing; update tests

### DIFF
--- a/RingBuffer.hpp
+++ b/RingBuffer.hpp
@@ -8,7 +8,7 @@
 #include <algorithm>
 #include <cstring>
 #include <vector>
-#pragma
+#pragma once
 namespace buffers {
 
     template<typename T, size_t N, bool Overwrite = true>
@@ -55,11 +55,11 @@ namespace buffers {
                 return (*source_)[index_];
             }
             template<bool Z = C, typename std::enable_if<(!Z), int>::type* = nullptr>
-            [[nodiscard]] reference operator->() noexcept {
+            [[nodiscard]] pointer operator->() noexcept {
                 return &((*source_)[index_]);
             }
             template<bool Z = C, typename std::enable_if<(Z), int>::type* = nullptr>
-            [[nodiscard]] const_reference operator->() const noexcept {
+            [[nodiscard]] const_pointer operator->() const noexcept {
                 return &((*source_)[index_]);
             }
             [[nodiscard]] self_type& operator++() noexcept {
@@ -69,7 +69,7 @@ namespace buffers {
             }
             [[nodiscard]] self_type operator++(int) noexcept {
                 auto result = *this;
-                this->operator*();
+                ++(*this);
                 return result;
             }
             [[nodiscard]] size_type index() const noexcept {
@@ -161,9 +161,11 @@ using std::bool_constant;
             --size_;
             tail_ = ++tail_ %N;
         }
-        [[nodiscard]] reference back() noexcept { return reinterpret_cast<reference>(elements_[clamp(head_, 0UL, N - 1)]); }
+        [[nodiscard]] reference back() noexcept {
+            return reinterpret_cast<reference>(elements_[(head_ + N - 1) % N]);
+        }
         [[nodiscard]] const_reference back() const noexcept {
-            return const_cast<self_type*>(back)->back();
+            return const_cast<self_type*>(this)->back();
         }
         [[nodiscard]] reference front() noexcept { return reinterpret_cast<reference >(elements_[tail_]); }
         [[nodiscard]] const_reference front() const noexcept {
@@ -216,7 +218,7 @@ using std::bool_constant;
                 for (auto i = 0; i < size_; ++i)
                     // construct value in memory of aligned storage
                     // using inplace operator new
-                    new( elements_ + ((tail_ + i) % N)) T(rhs[tail_ + ((tail_ + i) % N)]);
+                    new( elements_ + ((tail_ + i) % N)) T(rhs[(tail_ + i) % N]);
             }catch(...) {
                 while(!empty()) {
                     destroy(tail_, bool_constant<std::is_trivially_destructible_v<value_type>>{});
@@ -231,7 +233,7 @@ using std::bool_constant;
 
                 // construct value in memory of aligned storage
                 // using inplace operator new
-                p =reinterpret_cast<storage_type *>(new(elements_ + ((tail_ + i) % N)) T(rhs[tail_ + ((tail_ + i) % N)]));
+                p =reinterpret_cast<storage_type *>(new(elements_ + ((tail_ + i) % N)) T(rhs[(tail_ + i) % N]));
                 if (!p) {
                     break;
                 }

--- a/test_main.cpp
+++ b/test_main.cpp
@@ -37,13 +37,14 @@ TEST(RingBufferTest, Test3) {
     b1.push_back(2);
     b1.push_back(3);
     EXPECT_EQ(b1.front(), 1);
-    EXPECT_EQ(b1.back(), 1);
+    EXPECT_EQ(b1.back(), 3);
     b1.push_back(4); // This should overwrite the first element (1)
 
     EXPECT_EQ(b1.front(), 2); // Oldest element is now 2
-    EXPECT_EQ(b1.back(), 2);  // Back should still be 2
+    EXPECT_EQ(b1.back(), 4);  // Newest element is now 4
     b1.pop_front(); // Remove the first element (2)
     EXPECT_EQ(b1.front(), 3); // Oldest element is now 3
+    EXPECT_EQ(b1.back(), 4);  // Newest element remains 4
 }
 
 TEST(RingBufferTest, Test4) {
@@ -55,7 +56,7 @@ TEST(RingBufferTest, Test4) {
     b1.push_back(4); // Add 4, buffer now contains {2, 3, 4}
 
     EXPECT_EQ(b1.front(), 2); // Oldest element is 2
-    EXPECT_EQ(b1.back(), 2);
+    EXPECT_EQ(b1.back(), 4);
 }
 
 TEST(RingBufferTest, Test5) {
@@ -67,6 +68,32 @@ TEST(RingBufferTest, Test5) {
 
     EXPECT_TRUE(b1.empty()); // Buffer should be empty
     EXPECT_EQ(b1.size(), 0); // Size should be 0
+}
+
+TEST(RingBufferTest, Test6IteratorOrder) {
+    ring_buffer<int, 3> b1;
+    b1.push_back(10);
+    b1.push_back(20);
+    b1.push_back(30);
+    b1.push_back(40); // overwrite 10
+
+    std::vector<int> values;
+    for (auto it = b1.cbegin(); it != b1.cend(); ++it) {
+        values.push_back(*it);
+    }
+
+    std::vector<int> expected = {20, 30, 40};
+    EXPECT_EQ(values, expected);
+}
+
+TEST(RingBufferTest, Test7ArrowOperator) {
+    ring_buffer<std::vector<int>, 2> b1;
+    b1.push_back(std::vector<int>{1, 2});
+    b1.push_back(std::vector<int>{3, 4});
+
+    auto it = b1.cbegin();
+    EXPECT_EQ(it->at(0), 1);
+    EXPECT_EQ((++it)->at(1), 4);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
### Motivation
- Remove an invalid preprocessor directive and make the header self-contained via `#pragma once` to avoid include problems.
- Correct iterator semantics (`operator->`, postfix `operator++`) and ensure `back()` and copy construction use correct wraparound/source indexing to avoid wrong element access in the circular buffer.
- Add unit tests to cover iterator order and `operator->` usage and to correct existing `back()` expectations.

### Description
- Replaced stray `#pragma` with `#pragma once` at the top of `RingBuffer.hpp`.
- Changed iterator `operator->` return types to `pointer` and `const_pointer` and made postfix `operator++` call `++(*this)` to advance correctly.
- Reimplemented `back()` to return the element at `(head_ + N - 1) % N` and fixed the `const` overload to delegate via `const_cast` to avoid incorrect calls.
- Fixed non-trivial copy construction indexing in `copy_impl` to use `rhs[(tail_ + i) % N]` in both exception and non-exception paths so elements are constructed from the correct source positions.
- Updated `test_main.cpp` to correct `back()` expectations and added `Test6IteratorOrder` and `Test7ArrowOperator` to validate iteration order and `operator->` behavior on const iterators.

### Testing
- Updated unit tests in `test_main.cpp` were committed but no automated test run was executed as part of this change.
- No CI/test results are available in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c7b3caaa4832786c98fe6602836b8)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes iterator semantics, wraparound indexing, and updates tests in `RingBuffer` implementation.
> 
>   - **Behavior**:
>     - Replaced `#pragma` with `#pragma once` in `RingBuffer.hpp` to ensure header is self-contained.
>     - Fixed iterator `operator->` return types to `pointer` and `const_pointer` in `RingBuffer.hpp`.
>     - Corrected `back()` implementation to use `(head_ + N - 1) % N` for correct wraparound indexing.
>     - Fixed copy construction indexing in `copy_impl` to use `rhs[(tail_ + i) % N]`.
>   - **Testing**:
>     - Updated `test_main.cpp` to correct `back()` expectations.
>     - Added `Test6IteratorOrder` and `Test7ArrowOperator` to validate iterator order and `operator->` behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=bugparty%2FRingBufferCpp&utm_source=github&utm_medium=referral)<sup> for 01b5281a68bcffcf667a3fa11ff467aa15837a0f. You can [customize](https://app.ellipsis.dev/bugparty/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed iterator advancement and dereferencing semantics
  * Corrected element access calculations during copy and move operations
  * Improved const-correctness in element access methods
  * Fixed arrow operator return type for proper pointer dereferencing

* **Tests**
  * Added test coverage for iterator ordering and arrow operator usage
  * Updated test expectations to reflect corrected behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->